### PR TITLE
Return exit code in the Update command

### DIFF
--- a/app/Commands/Update.php
+++ b/app/Commands/Update.php
@@ -38,21 +38,21 @@ class Update extends Command
      *
      * @return void
      */
-    public function handle(): void
+    public function handle(): ?int
     {
         if (! $this->isValidFlarumInstallation()) {
             $this->error("No valid Flarum installation found at your current path.");
-            exit;
+            return 1;
         }
 
         if (($lock = $this->getComposerLock()) === null) {
             $this->error("No vendor/composer/installed.json file found, it is need to verify your current installation status.");
-            exit;
+            return 1;
         }
 
         if (! $this->confirm("Analysing Flarum releases and extension compatibility requires sending your vendor/composer/installed.json file to Flagrow.io. Are you okay with us processing that information?")) {
             $this->comment("Okay, that is your right. This tool can't work without that file, sorry.").
-            exit;
+            return 1;
         }
 
         /** @var ProgressBar $progress */


### PR DESCRIPTION
The value returned from this method will be interpreted as the exit code by CLIs so they can gracefully handle errors. This will also make sure [the `terminate` method](https://github.com/flagrow/flarum-updater/blob/master/flarum-updater#L51) runs, and the application is shut down gracefully.

`1` being an error exit code, `0` (or `null`) indicates "success" (or at least non-error).